### PR TITLE
Syntax/grammar improvement

### DIFF
--- a/README
+++ b/README
@@ -28,13 +28,27 @@ be broken up onto several lines:
     abc
   }
 
-The data can be structued into objects (think of it as a hash-map) by
-adding a {}-pair after the key.  The content of the object is key-value
-pairs or other objects.
+The '=' character is optional, so this is also a valid array:
+
+  key { 1 2 abc }
+
+The data can be structued into objects (think of it as a hash-map).
+Objects are much like lists except the content is key-value pairs
+or other named objects.
 
   name {
     key = value
     what = foo
+    obj {
+      who = bar
+    }
+  }
+
+Arrays may also contain unnamed objects:
+
+  stuff = {
+    { foo = bar }
+    { hey = you }
   }
 
 Keys and values are regular strings that can contain any characters

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@
 from distutils.core import setup
 
 setup(name='structprop',
-      version='0.0.6',
+      version='0.1.0',
       description='Parser for structured property config file format',
-      author='Johan Rydberg',
-      author_email='johan.rydberg@gmail.com',
+      author='Johan Rydberg, Mikael Langer',
+      author_email='johan.rydberg@gmail.com, mikael.langer@gmail.com',
       license="MIT",
       py_modules=['structprop'],
       classifiers=[

--- a/structprop.py
+++ b/structprop.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2011 by Edgeware AB.
-# Written by Johan Rydberg <johan.rydberg@gmail.com>
+# Written by Johan Rydberg <johan.rydberg@gmail.com>,
+#            Mikael Langer <mikael.langer@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test.py
+++ b/test.py
@@ -44,7 +44,11 @@ class ParserTestCase(unittest.TestCase):
 
     def test_object_key_value(self):
         result = loads("a { key = value }")
-        self.assertEquals(result['a']['key'], 'value')
+        self.assertEquals(result, {'a': {'key': 'value'}})
+
+    def test_object_key_value_optional_assign(self):
+        result = loads("a = { key = value }")
+        self.assertEquals(result, {'a': {'key': 'value'}})
 
     def test_comment_before_data(self):
         result = loads(u"#xxx\na { key = value }")
@@ -56,6 +60,10 @@ class ParserTestCase(unittest.TestCase):
         self.assertEquals(len(result['a']), 4)
         self.assertEquals(result['a'][2], 'def')
         self.assertEquals(result['a'][3], 'abc')
+
+    def test_list_optional_assign(self):
+        result = loads(u"a { abc def }")
+        self.assertEquals(result, {'a': ['abc', 'def']})
 
     def test_true_bool(self):
         result = loads('a = true')
@@ -81,6 +89,17 @@ a = {
         self.assertEquals(data, """\
 a {
   d = 1
+}
+""")
+
+    def test_dump_list_dict(self):
+        data = dumps({'a': [{'b': 1}]})
+        loads(data)
+        self.assertEquals(data, """\
+a = {
+  {
+    b = 1
+  }
 }
 """)
 


### PR DESCRIPTION
Improve syntax mainly to make '=' optional in front of lists.
Thus, lists and objects are only differentiated by their content:
key-value pairs => object
strings or anonymous objects => list

Example:
a { b = 1 c = 2 } => {'a':{'b': 1, 'c': 2}}
a { b c } => {'a':['b', 'c']}

The result is that to the user, named objects only represent nested structures,
and she will never have to figure out whether the content is parsed as an object
or list and include or exclude the '=' accordingly.