### PR TITLE
Add 'ordereddict' as a dependency for < Py2.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
+import sys
+
 from setuptools import setup, find_packages
+
+install_requires = []
+
+if sys.version_info < (2, 7):
+    install_requires.append('ordereddict')
 
 setup(name='structprop',
       version='0.0.9',
@@ -8,6 +15,7 @@ setup(name='structprop',
       license='MIT',
       packages=find_packages(),
       test_suite='structprop.test',
+      install_requires=install_requires,
       classifiers=[
           'Intended Audience :: Developers',
           'Topic :: Software Development'

--- a/structprop/__init__.py
+++ b/structprop/__init__.py
@@ -20,19 +20,12 @@
 
 
 import json
-import sys
 
-# Try to find an implementation of OrderedDict
-if sys.version_info >= (2, 7):
+try:
+    # Python 2.7+
     from collections import OrderedDict
-else:
-    try:
-        from ordereddict import OrderedDict
-    except ImportError:
-        # Fall back to ordinary dicts if all else fails. This means
-        # that the order of elements in an object will not be preserved.
-        OrderedDict = dict
-        print ("Warning: no OrderedDict implementation found.")
+except ImportError:
+    from ordereddict import OrderedDict
 
 
 NEWLINE = (u'NEWLINE',)


### PR DESCRIPTION
Seems like a dangerous practice to fallback to using a `dict` instead of `OrderedDict` when order of the keys is supposed to be guaranteed.
